### PR TITLE
Update README: pull_request -> pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: 'Auto Author Assign'
-on: [pull_request_target]
+on: [pull_request, pull_request_target]
 jobs:
   add-assignees:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: 'Auto Author Assign'
-on: [pull_request]
+on: [pull_request_target]
 jobs:
   add-assignees:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: 'Auto Author Assign'
-on: [pull_request, pull_request_target]
+on: [pull_request_target]
 jobs:
-  add-assignees:
+  assign-author:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This action automatically assigns PR author as an assignee.
 name: 'Auto Author Assign'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ on:
     types: [opened, reopened]
 
 jobs:
-  add-assignees:
+  assign-author:
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v1.1.0


### PR DESCRIPTION
Closes #22

> pull_request_target
> This event is similar to pull_request, except that it runs in the context of the base repository of the pull request, rather than in the merge commit.

ref. https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target

> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload.

ref. https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

## Related Issue

https://github.com/actions/labeler/issues/12