### PR TITLE
Add new Github permissions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   assign-author:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github is restricting the permissions that actions have to the repositories. To make the auto-assign author action work correctly, you need to add the necessary permissions to the YML file.

https://docs.github.com/en/actions/reference/authentication-in-a-workflow#example-1-passing-the-github_token-as-an-input