### PR TITLE
Remove required flag and `contents: read` permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ on:
     types: [opened, reopened]
 
 permissions:
-  contents: read
   pull-requests: write
 
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,6 @@ author: 'toshimaru'
 inputs:
   repo-token:
     description: 'A token for the repository'
-    required: true
     default: '${{ github.token }}'
 runs:
   using: 'node12'


### PR DESCRIPTION
## Changes

- `contents: read` is not a required permission, so remove it
- Remove required flag from `repo-token` since default value is set
