### PR TITLE
Use new endpoints released with actions/github v5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ async function run() {
     }
 
     const octokit = getOctokit(token);
-    const result = await octokit.issues.addAssignees({
+    const result = await octokit.rest.issues.addAssignees({
       owner: context.repo.owner,
       repo: context.repo.repo,
       issue_number: number,


### PR DESCRIPTION
## Description
- [Update @actions/github v.5.0.0](https://github.com/actions/toolkit/pull/783), it made change to the definition of the octokit object. 
- currently `Cannot read property 'addAssignees' of undefined` error happens.